### PR TITLE
Refactored scorer as an extension type

### DIFF
--- a/cpt/Cpt.pyx
+++ b/cpt/Cpt.pyx
@@ -4,7 +4,7 @@ from itertools import combinations
 from cpt cimport utilities
 from cpt.PredictionTree import PredictionTree
 from cpt cimport alphabet
-from cpt.Scorer import Scorer
+from cpt.scorer cimport Scorer
 
 
 class Cpt():

--- a/cpt/scorer.pxd
+++ b/cpt/scorer.pxd
@@ -1,0 +1,3 @@
+cdef class Scorer:
+	cdef public int alphabet_length
+	cdef public list scoring

--- a/cpt/scorer.pyx
+++ b/cpt/scorer.pyx
@@ -1,18 +1,22 @@
 import heapq
 
 
-class Scorer():
-    def __init__(self, alphabet_length):
+cdef class Scorer:
+    def __cinit__(self, alphabet_length):
         self.alphabet_length = alphabet_length
         self.scoring = [0] * alphabet_length
 
     def predictable(self):
         return any(self.scoring)
 
-    def update(self, consequent_element):
+    def update(self, int consequent_element):
         self.scoring[consequent_element] += 1
 
     def best_n_predictions(self, number_predictions):
+
+        def get_score(int i):
+            return self.scoring[i]
+
         return heapq.nlargest(number_predictions,
                               range(self.alphabet_length),
-                              key=lambda i: self.scoring[i])
+                              key=get_score)

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,6 +1,6 @@
 import unittest
 
-from cpt.Scorer import Scorer
+from cpt.scorer import Scorer
 
 
 class ScorerTest(unittest.TestCase):


### PR DESCRIPTION
| name | previous | now |
| --- | --- | --- |
| total | 41.3 | 33.1 |
| lambda/get_score | 4.9 | 2.9 |
| predict_seq | 13 | 7 |
| update | 0.45 | 0.25 |
| lambda cython / predict_seq | 3.4 | 2.9 |

The lambda function is replaced by a python method for type declaration, this method will be optimized in a next commit.
