### PR TITLE
[ISSUE-84] Fixup bug which made CPT could not predict a value already in target sequence

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -18,6 +18,6 @@ With `FIFA.dat` in the data folder, you can run the benchmark from the root fold
 
 ## Results
 
-Using multithreading, `CPT` made 4869 predictions per second, which is an average of 0.2 ms per prediction.
+Using multithreading, `CPT` made 2435 predictions per second, which is an average of 0.4 ms per prediction.
 
-However, most use cases do not take advantage of multithreading. Without multithreading, `CPT` made 1662 predictions per second, which is an average of 0.6 ms per prediction.
+However, most use cases do not take advantage of multithreading. Without multithreading, `CPT` made 831 predictions per second, which is an average of 1.2 ms per prediction.

--- a/cpt/cpt.pxd
+++ b/cpt/cpt.pxd
@@ -14,6 +14,7 @@ cdef class Cpt:
         int predict_seq(self, vector[int] target_sequence, vector[int] least_frequent_items) nogil
         vector[int] predict_seq_k(self, vector[int] target_sequence, vector[int] least_frequent_items, int k=*) nogil
         Scorer make_scorer(self, vector[int], vector[int]) nogil
+        vector[int] c_retrieve_reversed_sequence(self, int index) nogil
         vector[int] c_compute_noisy_items(self, float noise_ratio) nogil
         Bitset c_find_similar_sequences(self, vector[int] sequence) nogil
         int update_score(self, vector[int] suffix, Scorer& score) nogil

--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -38,15 +38,15 @@ class CptTest(unittest.TestCase):
 
         self.cpt.noise_ratio = 1
         self.cpt.MBR = 3
-        self.assertEqual(self.cpt.predict([['A'], ['A', 'B']]), ['B', 'D'])
+        self.assertEqual(self.cpt.predict([['A'], ['A', 'B']]), ['B', 'C'])
         # Test if predictions are the same with multi threading turned off
-        self.assertEqual(self.cpt.predict([['A'], ['A', 'B']], False), ['B', 'D'])
+        self.assertEqual(self.cpt.predict([['A'], ['A', 'B']], False), ['B', 'C'])
 
         self.cpt.MBR = 2
         self.assertEqual(self.cpt.predict([['A', 'B']]), ['C'])
 
         self.cpt.noise_ratio = 0.2
-        self.cpt.MBR = 1
+        self.cpt.MBR = 2
         self.assertEqual(self.cpt.predict([['B', 'D', 'E']]), ['E'])
         # Default value is the first of the alphabet
         self.cpt.noise_ratio = 0.1


### PR DESCRIPTION
Bug fix where subsequent of `BAAC` should be `AC` and not `C`.
Full story [here](https://medium.com/@rafaelktistakis/just-reading-through-the-comments-and-the-question-raised-by-christopher-a78295440baf)